### PR TITLE
fix: 修复`fishbot_description`中`package.xml`造成的编译错误

### DIFF
--- a/src/fishbot_description/package.xml
+++ b/src/fishbot_description/package.xml
@@ -6,8 +6,6 @@
   <description>TODO: Package description</description>
   <maintainer email="root@todo.todo">root</maintainer>
   <license>TODO: License declaration</license>
-
-  <buildtool_depend>ament_python</buildtool_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
修复编译时提示`Cannot locate rosdep definition for [ament_python]`的问题。