### PR TITLE
Repair urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "src/navigation"]
 	path = src/navigation
-	url = http://github.fishros.org/https://github.com/fishros/navigation2.git
+	url = https://github.com/fishros/navigation2.git
 	branch = main
 [submodule "src/cartographer_code/cartographer"]
 	path = src/cartographer_code/cartographer
-	url = http://github.fishros.org/https://github.com/ros2/cartographer.git
+	url = https://github.com/ros2/cartographer.git
 [submodule "src/cartographer_code/cartographer_ros"]
 	path = src/cartographer_code/cartographer_ros
-	url = http://github.fishros.org/https://github.com/ros2/cartographer_ros.git
+	url = https://github.com/ros2/cartographer_ros.git


### PR DESCRIPTION
In order to fix "
fatal: unable to access 'http://github.fishros.org/https://github.com/fishros/navigation2.git/': The requested URL returned error: 403 "