### PR TITLE
remove <buildtool_depend>ament_python</buildtool_depend>

### DIFF
--- a/src/fishbot_description/package.xml
+++ b/src/fishbot_description/package.xml
@@ -6,8 +6,6 @@
   <description>TODO: Package description</description>
   <maintainer email="root@todo.todo">root</maintainer>
   <license>TODO: License declaration</license>
-
-  <buildtool_depend>ament_python</buildtool_depend>
   
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
# Solve issue:
Cannot locate rosdep definition for [ament_python]
# Refer link:
https://github.com/ros2/ros2_documentation/issues/508